### PR TITLE
Align `memory.copy` arg types with `memory64` proposal

### DIFF
--- a/include/wabt/type-checker.h
+++ b/include/wabt/type-checker.h
@@ -99,7 +99,7 @@ class TypeChecker {
   Result OnLocalSet(Type);
   Result OnLocalTee(Type);
   Result OnLoop(const TypeVector& param_types, const TypeVector& result_types);
-  Result OnMemoryCopy(const Limits& limits);
+  Result OnMemoryCopy(const Limits& srclimits, const Limits& dstlimits);
   Result OnDataDrop(Index);
   Result OnMemoryFill(const Limits& limits);
   Result OnMemoryGrow(const Limits& limits);

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -909,10 +909,11 @@ Result SharedValidator::OnMemoryCopy(const Location& loc,
                                      Var srcmemidx,
                                      Var destmemidx) {
   Result result = CheckInstr(Opcode::MemoryCopy, loc);
-  MemoryType mt;
-  result |= CheckMemoryIndex(srcmemidx, &mt);
-  result |= CheckMemoryIndex(destmemidx, &mt);
-  result |= typechecker_.OnMemoryCopy(mt.limits);
+  MemoryType srcmt;
+  MemoryType dstmt;
+  result |= CheckMemoryIndex(srcmemidx, &srcmt);
+  result |= CheckMemoryIndex(destmemidx, &dstmt);
+  result |= typechecker_.OnMemoryCopy(srcmt.limits, dstmt.limits);
   return result;
 }
 

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -706,8 +706,16 @@ Result TypeChecker::OnLoop(const TypeVector& param_types,
   return result;
 }
 
-Result TypeChecker::OnMemoryCopy(const Limits& limits) {
-  return CheckOpcode3(Opcode::MemoryCopy, &limits, &limits, &limits);
+Result TypeChecker::OnMemoryCopy(const Limits& src_limits,
+                                 const Limits& dst_limits) {
+  Limits size_limits = src_limits;
+  // The memory64 proposal specifies that the type of the size argument should
+  // be the mimimum of the two memory types.
+  if (src_limits.is_64 && !dst_limits.is_64) {
+    size_limits = dst_limits;
+  }
+  return CheckOpcode3(Opcode::MemoryCopy, &src_limits, &dst_limits,
+                      &size_limits);
 }
 
 Result TypeChecker::OnDataDrop(uint32_t segment) {

--- a/test/parse/expr/bad-memory-copy-differing-type.txt
+++ b/test/parse/expr/bad-memory-copy-differing-type.txt
@@ -1,0 +1,122 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+;;; ARGS: --enable-all
+
+(;
+Note that this test covers an interaction between the memory64 and
+multi-memory proposals.
+
+Neither proposal includes a test like this because each proposal only
+implements itself on top of the current standard. Once one of the two proposals
+is standardized, this test should be removed in favor of a spec test in the
+proposal that is yet to be standardized.
+;)
+
+(module
+  (memory $mem64 i64 1)
+  (memory $mem32 i32 1)
+  (func
+    (; i64 -> i32 ;)
+    i64.const 0
+    i64.const 0
+    i32.const 0
+    memory.copy $mem32 $mem64
+
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $mem32 $mem64
+
+    i32.const 0
+    i64.const 0
+    i64.const 0
+    memory.copy $mem32 $mem64
+
+    (; i32 -> i64 ;)
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $mem64 $mem32
+
+    i64.const 0
+    i64.const 0
+    i32.const 0
+    memory.copy $mem64 $mem32
+
+    i64.const 0
+    i32.const 0
+    i64.const 0
+    memory.copy $mem64 $mem32
+
+    (; i64 -> i64 ;)
+    i32.const 0
+    i64.const 0
+    i64.const 0
+    memory.copy $mem64 $mem64
+
+    i64.const 0
+    i32.const 0
+    i64.const 0
+    memory.copy $mem64 $mem64
+
+    i64.const 0
+    i64.const 0
+    i32.const 0
+    memory.copy $mem64 $mem64
+
+    (; i32 -> i32 ;)
+    i64.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $mem32 $mem32
+
+    i32.const 0
+    i64.const 0
+    i32.const 0
+    memory.copy $mem32 $mem32
+
+    i32.const 0
+    i32.const 0
+    i64.const 0
+    memory.copy $mem32 $mem32
+  )
+)
+
+(;; STDERR ;;;
+out/test/parse/expr/bad-memory-copy-differing-type.txt:23:5: error: type mismatch in memory.copy, expected [i32, i64, i32] but got [i64, i64, i32]
+    memory.copy $mem32 $mem64
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:28:5: error: type mismatch in memory.copy, expected [i32, i64, i32] but got [i32, i32, i32]
+    memory.copy $mem32 $mem64
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:33:5: error: type mismatch in memory.copy, expected [i32, i64, i32] but got [i32, i64, i64]
+    memory.copy $mem32 $mem64
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:39:5: error: type mismatch in memory.copy, expected [i64, i32, i32] but got [i32, i32, i32]
+    memory.copy $mem64 $mem32
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:44:5: error: type mismatch in memory.copy, expected [i64, i32, i32] but got [i64, i64, i32]
+    memory.copy $mem64 $mem32
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:49:5: error: type mismatch in memory.copy, expected [i64, i32, i32] but got [i64, i32, i64]
+    memory.copy $mem64 $mem32
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:55:5: error: type mismatch in memory.copy, expected [i64, i64, i64] but got [i32, i64, i64]
+    memory.copy $mem64 $mem64
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:60:5: error: type mismatch in memory.copy, expected [i64, i64, i64] but got [i64, i32, i64]
+    memory.copy $mem64 $mem64
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:65:5: error: type mismatch in memory.copy, expected [i64, i64, i64] but got [i64, i64, i32]
+    memory.copy $mem64 $mem64
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:71:5: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i32]
+    memory.copy $mem32 $mem32
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:76:5: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i32]
+    memory.copy $mem32 $mem32
+    ^^^^^^^^^^^
+out/test/parse/expr/bad-memory-copy-differing-type.txt:81:5: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
+    memory.copy $mem32 $mem32
+    ^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/parse/expr/memory-copy-differing-type.txt
+++ b/test/parse/expr/memory-copy-differing-type.txt
@@ -1,0 +1,35 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-all
+
+(;
+Note that this test covers an interaction between the memory64 and
+multi-memory proposals.
+
+Neither proposal includes a test like this because each proposal only
+implements itself on top of the current standard. Once one of the two proposals
+is standardized, this test should be removed in favor of a spec test in the
+proposal that is yet to be standardized.
+;)
+
+(module
+  (memory $mem64 i64 1)
+  (memory $mem32 i32 1)
+  (func
+    i32.const 0
+    i64.const 0
+    i32.const 0
+    memory.copy $mem32 $mem64
+    i64.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $mem64 $mem32
+    i64.const 0
+    i64.const 0
+    i64.const 0
+    memory.copy $mem64 $mem64
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $mem32 $mem32
+  )
+)


### PR DESCRIPTION
When both the `multi-memory` and `memory64` features are enabled it's
possible for `memory.copy` to copy between two memories of different
types. In this case, the `memory64` proposal specifies that the `src`
and `dst` arguments should correspond to the types of the memory they
are accessing, and the `size` argument should correspond to the
"minimum" of the two memory types [1]. That is, the `size` should be an
`i32` if either of the memories has type `i32` and it should be `i64` if
both of the memories have type `i64`.

This existing code just expects all three arguments to match the type of
the source memory which works whenever the source and destination
memories have the same type. This change adjusts that logic to agree
with the `memory64` proposal in the cases where the two memories have
differing types.

[1]
https://github.com/WebAssembly/memory64/blob/5bfb70d9888b96a2f3d6412ed3599b91364da610/proposals/memory64/Overview.md?plain=1#L211